### PR TITLE
fix github-actions bot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,7 +2,7 @@
 shared:
   automated_prs: &automated_prs
     - "author=cloudpossebot"
-    - "author=github-actions"
+    - "author=github-actions[bot]"
   default_branch: &default_branch
     - "base=main"
     - "base=master"


### PR DESCRIPTION
## what
* The `github-actions` app should be referred to as `github-actions[bot]`

## why
* For auto-merging rules