### PR TITLE
Cut releases when workflows change

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
       - release/**
+    # This .github organization is a special case for the release branch
+    # We want to cut releases when github reusable/shared workflows change.
+    # So we should not skip .github/** paths
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
@@ -15,7 +17,6 @@ on:
 permissions:
   contents: write
   id-token: write
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -83,9 +84,13 @@ jobs:
         run: |
           git diff --exit-code && success="true" || success="false"
           if [ "$success" = "false" ]; then
-            echo "README.md is outdated. Please run the following commands locally and push the file:"
-            echo "  make init"
-            echo "  make readme"
+            echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
+            echo "> ## README.md is outdated." >> $GITHUB_STEP_SUMMARY
+            echo "> Please run the following commands locally and push the file:" >> $GITHUB_STEP_SUMMARY
+            echo '> ```shell' >> $GITHUB_STEP_SUMMARY
+            echo '> make init' >> $GITHUB_STEP_SUMMARY
+            echo '> make readme' >> $GITHUB_STEP_SUMMARY
+            echo '> ```' >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 


### PR DESCRIPTION
## what
- Adjust the conditions for cutting a release to include changes to .github

## why
- We'll be pinning to releases of this configuration repository