### PR TITLE
Test using readme action

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -16,7 +16,6 @@ permissions:
   contents: write
   id-token: write
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -32,62 +31,12 @@ jobs:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate readme
-        shell: bash
-        run: |
-          if [ ! -f README.yaml ]; then
-            echo "Project does not have a README.yaml. Skipping..."
-            exit 0
-          fi
-
-          # A Makefile is required for build-harness and rebuilding the README.md from the README.yaml and rebuilding the README.md from the README.yaml and rebuilding the README.md from the README.yaml and rebuilding the README.md from the README.yaml
-          if [ ! -f Makefile ]; then
-            echo "Project does not have a Makefile";
-            exit 1
-          fi
-
-          make init
-          make readme/build
-
-      - name: Check readme
-        id: readme_diff
-        shell: bash
-        run: git diff --exit-code
-        continue-on-error: true
-
-      - name: Auto-update README.md for bot pull requests
-        id: auto_commit
-        if: |
-          steps.readme_diff.outcome == 'failure' && 
-          (
-            startsWith(github.ref, 'security/') ||
-            startsWith(github.ref, 'auto-update/') ||
-            startsWith(github.ref, 'dependabot/') ||
-            startsWith(github.ref, 'renovate/')
-          )
-        # Update existing PR for jobs running in a PR (e.g. non-default branch)
-        # Protected branches will need a GitHub App to update the PR
-        uses: stefanzweifel/git-auto-commit-action@v5
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app.outputs.token }}
+      - uses: cloudposse-github-action/readme@main
         with:
-          commit_message: "chore: update README.md"
-          commit_user_name: github-actions[bot]
-          commit_user_email: 'github-actions[bot]@users.noreply.github.com'
-
-      - name: Status check
-        shell: bash
-        run: |
-          git diff --exit-code && success="true" || success="false"
-          if [ "$success" = "false" ]; then
-            echo "README.md is outdated. Please run the following commands locally and push the file:"
-            echo "  make init"
-            echo "  make readme"
-            exit 1
-          fi
+          token: ${{ steps.github-app.outputs.token }}
+          readme_enabled: true
+          banner_enabled: true
+          commit_method: 'commit'
 
   release-controller:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ runs:
       branch: 'auto-update/scaffolding'
       base: ${{ steps.repo.outputs.branch }}
       title: 'Update Repository Scaffolding'
+      labels: |
+        auto-update
+        scaffolding
+        no-release
       body: |
         ## what
         - This pull request includes the scaffolding files overlaid onto the repository.

--- a/scaffolding/github-action/.github/mergify.yml
+++ b/scaffolding/github-action/.github/mergify.yml
@@ -1,1 +1,1 @@
-extends: cloudposse-github-actions/.github
+extends: .github

--- a/scaffolding/github-action/.github/settings.yml
+++ b/scaffolding/github-action/.github/settings.yml
@@ -1,2 +1,2 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
-extends: cloudposse-github-actions/.github
+_extends: .github


### PR DESCRIPTION
## what
* Rip out the previous implementation and replace with `readme` action
* Always rebuild readme and do so in the security context so we can push to main

## why
* READMEs out of date is the most common issue preventing releases
* No reason we cannot just always generate it