### PR TITLE
Specify config for auto-release

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -66,6 +66,7 @@ jobs:
         uses: cloudposse/github-action-auto-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          config-name: auto-release.yml
 
   major-release-tagger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## what
- Use `.github/auto-release.yml` instead of `.github/configs/auto-release.yml`

## why
- The upstream action changed it's path to `configs/draft-release.yml`
- Our configs in 99% our repos use `auto-release.yml`
- Since we can't move 99% of the locations of configs like settings.yml or mergify.yml, introducing a `configs/` folder only makes configs *more* disbursed