### PR TITLE
Added migrations script

### DIFF
--- a/migrate/.gitignore
+++ b/migrate/.gitignore
@@ -1,0 +1,3 @@
+.build-harness
+build-harness
+tmp/**

--- a/migrate/Makefile
+++ b/migrate/Makefile
@@ -1,0 +1,3 @@
+deps:
+	brew install gh yq
+	pip3 install yamlfix

--- a/migrate/README.md
+++ b/migrate/README.md
@@ -1,0 +1,53 @@
+## Usage
+
+Create a migration script in [`migrations/<date>/script.sh`](migrations/) and use the helpers in [`lib/`](lib/).
+
+```shell
+# Export this environment variable to actually create and merge PRs
+export XARGS_DRY_RUN=false 
+
+# Pass the migration and the list of repos in the migration to process.
+./git-xargs.sh 20240304 repos.txt
+```
+
+## How it Works
+
+The `lib/` folder contains helper libraries (bash).  Define one file per tool. See the existing libraries for conventions.
+
+The `migrations/` folder contains subfolders, one per migration. By convention, we should use dates (e.g. `20230302`).
+
+Inside each date-based migration folder, there should be a few files.
+- `README.md` which will both describe the migration and be used as the body of the PR.
+- `repos.txt` a list of repos which this migration applies to. You can also batch this using the `split` command.
+- `script.sh` a script that is invoked in the context of the library and will perform the migration operations
+
+There's a `templates/` folder, which contains a number of subfolders. Each subfolder represents a repository type.
+Including a `default` folder, which is used when no files are found for a given repository type.
+
+## Helper Functions
+
+- The `template_file` function will use the `REPO_TYPE` environment variable to find the best template file. It searches from the most specific to the list specific (e.g., `defaults/``)
+- The `info` function emits a friendly message
+- The `error` function emits the error and exits 1
+- The `title` function sets the title that will be used subsequently when the PR is opened
+- The `install` function will use the `template_file` function to install a file from one of the suitable templates
+- THe `gh` function will call the `gh` command but respect GitHub API rate limits
+
+## Tips & Tricks
+
+1. Use `yq` for manipulating YAML. It will preserve comments but not whitespace. It will also replace Unicode characters with their escape sequence. Use `yamlfix` to restore the Unicode character.
+2. Use `yamlfix` to format YAML and normalize whitespace.
+3. Create a list of repos using the `gh repo list` command
+
+<details><summary>Past Limitations Using `git-xargs` CLI</summary>
+
+## Notable Limitations
+
+We encountered significant obstacles using `git-xargs`. Here they are for posterity.
+
+- `git-xargs` cannot add labels
+- `git-xargs` [ignores `.gitignore`](https://github.com/gruntwork-io/git-xargs/issues/53), so it's best to handle clean-up before exiting the script
+- `git-xargs` will not update PR title/description, so it's advisable to just use `gh` CLI instead
+- `git-xargs` cannot auto-merge, so use `gh-cli` in script to commit, push, open PR, then merge
+- Using `gh-cli` to bypass the `git-xargs` deficiencies, means rate limiting isn't respected by `git-xargs`
+</details>

--- a/migrate/git-xargs.sh
+++ b/migrate/git-xargs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Due to just endless problems working around `git-xargs` limitations, challenges with rate limits,
+# resorting to a basic shell script that does the same thing, but with more control and less magic and no parallelism.
+set -e
+
+migration=$1
+batch=$2
+
+# Validate usage
+if [[ -z "$migration" || -z "$batch" ]]; then
+    echo "Usage: $0 <migration_branch> <batch>"
+    exit 1
+fi
+curdir=$(pwd)
+migration_branch="migration/${migration}"
+migration_dir="migrations/${migration}"
+repos="${migration_dir}/${batch}"
+
+# Test if the repo file exists
+if [[ ! -f "$repos" ]]; then
+  echo "Repo file for ${batch} batch does not exist: $repos"
+  exit 1
+fi
+
+if [[ ! -d "migrations/${migration}" ]]; then
+  echo "Migration does not exist: $migration"
+  exit 1
+fi
+
+while IFS= read -r repo; do
+  if [[ $repo == \#* ]]; then
+    continue
+  fi
+  cd "${curdir}" 
+  repo_name=$(basename "$repo" .git)
+  repo_owner=$(basename "$(dirname "$repo")")
+  repo_url="git@github.com:${repo_owner}/${repo_name}.git"
+  tmp_dir="tmp/$repo_owner/$repo_name"
+
+  echo "Processing $repo_url"
+  if [[ ! -d "$tmp_dir" ]]; then
+    mkdir -p $(dirname "$tmp_dir")
+    git clone "$repo_url" "${tmp_dir}"
+  fi
+
+  cd "${tmp_dir}" || exit
+
+  # Identify the default branch
+  default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+
+  git checkout "${default_branch}"
+  # Ensure our branch is reset to match the remote default branch, so that we can apply the migration cleanly
+  git reset --hard origin/${default_branch}
+  git pull origin "${default_branch}"
+
+  if git rev-parse --verify "${migration_branch}" >/dev/null 2>&1; then
+    echo "Deleting existing ${migration_branch} branch"
+    git branch -D "${migration_branch}"
+  fi
+  echo "Creating ${migration_branch} branch"
+  git checkout -b "${migration_branch}"
+
+  # Always start clean
+  git clean -fxd
+
+  export XARGS_DRY_RUN=${XARGS_DRY_RUN:-true}
+  export XARGS_REPO_NAME="${repo_name}"
+  export XARGS_REPO_OWNER="${repo_owner}"
+  export MIGRATE_PATH="${curdir}"
+  echo "Performing migration..."
+  $curdir/run.sh "${migration}"
+  if [[ $? -ne 0 ]]; then
+    echo "Migration failed for ${repo}"
+    exit 1
+  fi
+
+done < "${repos}"

--- a/migrate/lib/codeowners.sh
+++ b/migrate/lib/codeowners.sh
@@ -1,0 +1,4 @@
+function install_codeowners() {
+    info "Installing CODEOWNERS"
+    install CODEOWNERS
+}

--- a/migrate/lib/common.sh
+++ b/migrate/lib/common.sh
@@ -1,0 +1,124 @@
+function title() {
+    export TITLE="$1"
+}
+
+function error() {
+    printf "“❌ \e[31mError: %s\e[0m\n" "$*" >&2
+    exit 1
+}
+
+function info() {
+    printf "✅︎ %s\n" "$*" >&2
+}
+
+function gh() {
+  while true; do
+    # Check the GitHub API rate limit
+    rate_limit=$(command gh api rate_limit | jq '.resources.core.remaining')
+    
+    # Print the current rate limit
+    info "GitHub API rate limit: $rate_limit remaining"
+    
+    # If the rate limit is sufficient, break the loop
+    if (( rate_limit > 10 )); then
+      break
+    fi
+    
+    # Sleep for 60 seconds before checking the rate limit again
+    info "Rate limit too low, sleeping for 60 seconds..."
+    sleep 60
+  done
+  
+  # Call the gh command with the provided arguments
+  command gh "$@"
+  exit_code=$?
+  # Generate a random number between 500 and 3000 (representing milliseconds)
+  random_milliseconds=$(( RANDOM % 2500 + 500 ))
+
+  # Convert milliseconds to seconds
+  random_seconds=$(echo "scale=3; $random_milliseconds / 1000" | bc)
+  
+  # Sleep for the random amount of time
+  sleep $random_seconds
+  return $exit_code
+}
+
+
+function install() {
+    local source=${1}
+    local destination=${2:-$source}
+    local source_file=$(template_file $source)
+    if [ -f "${source_file}" ]; then
+        info "Installing file $destination from $source_file"
+        cp -a $source_file $destination
+        git add $destination
+		elif [ -d "${source_file}" ]; then
+        info "Installing directory $destination from $source_file"
+				mkdir -p $destination
+        cp -a $source_file/ $destination/
+        git add $destination
+    else
+        error "Template not found: $source"
+    fi
+}
+
+function remove() {
+    local file=${1}
+		git rm --force --ignore-unmatch $file
+}
+
+function auto_merge() {
+    export AUTO_MERGE=${1:-true}
+}
+
+function template_file() {
+    if [ -f ${MIGRATE_PATH}/templates/${REPO_TYPE}/$1 ]; then
+        echo ${MIGRATE_PATH}/templates/${REPO_TYPE}/$1
+    elif [ -f ${MIGRATE_PATH}/templates/default/$1 ]; then
+        echo ${MIGRATE_PATH}/templates/default/$1
+    elif [ -d ${MIGRATE_PATH}/templates/${REPO_TYPE}/$1 ]; then
+        echo ${MIGRATE_PATH}/templates/${REPO_TYPE}/$1
+    elif [ -d ${MIGRATE_PATH}/templates/default/$1 ]; then
+        echo ${MIGRATE_PATH}/templates/default/$1
+    else
+        error "Template not found: $1"
+    fi
+}
+
+function repo_type() {
+    if [ -f "main.tf" ]; then
+        export REPO_TYPE="terraform-module"
+    elif [[ "${XARGS_REPO_NAME}" =~ "terraform-provider" ]]; then
+        export REPO_TYPE="terraform-provider"
+    elif [[ "${XARGS_REPO_NAME}" =~ "terraform-" ]]; then
+        export REPO_TYPE="terraform-module"
+    elif [ "${XARGS_REPO_NAME}" == "test" ]; then
+        export REPO_TYPE="test"
+    elif [ -f "action.yml" ]; then
+        export REPO_TYPE="github-action"
+    elif [ -f "Dockerfile" ]; then
+        export REPO_TYPE="docker"
+    elif [ -f "package.json" ]; then
+        export REPO_TYPE="node"
+    else
+        export REPO_TYPE="default"
+    fi
+}
+
+
+function create_labels() {
+    # Ideally this would happen by `.github/settings.yml`, however there's an order of 
+    # operations issue, since the labels we use may not yet have been synced to the repo.
+    # So instead, let's create them now, and let them get updated/corrected later.
+
+    IFS=',' read -ra required_labels <<< "$LABELS"
+
+    local existing_labels=$(gh label list --json name  --jq '.[].name')
+
+    for label in "${required_labels[@]}"; do
+        if ! echo "$existing_labels" | grep -q "$label"; then
+            gh label create "$label" -c '#b60205'
+            info "Created label [$label]"
+        fi
+    done
+}

--- a/migrate/lib/dependabot.sh
+++ b/migrate/lib/dependabot.sh
@@ -1,0 +1,4 @@
+function install_dependabot() {
+    info "Installing Dependabot"
+    install .github/dependabot.yml
+}

--- a/migrate/lib/editorconfig.sh
+++ b/migrate/lib/editorconfig.sh
@@ -1,0 +1,4 @@
+function install_editorconfig() {
+  info "Installing EditorConfig"
+  install .editorconfig
+}

--- a/migrate/lib/github-settings.sh
+++ b/migrate/lib/github-settings.sh
@@ -1,0 +1,40 @@
+function install_github_settings() {
+    # IMPORTANT `settings.yml` uses `_extends` keyword and mergify uses `extends` keyword
+    info "Installing GitHub settings"
+    local settings=".github/settings.yml"
+
+    mkdir -p $(dirname $settings)
+    if [ -f $settings ]; then
+        info "GitHub settings already installed"
+        # Ensure it's always extending from the .github repo
+        yq -ei '._extends = ".github"' $settings
+
+        # Remove the erroneous extends key, if present
+        yq -ei 'del(.extends)' $settings
+    else 
+        info "GitHub settings not found, initializing to .github"
+        info "Creating $settings"
+        echo "_extends: .github" > $settings
+    fi
+    # Fetch the current name and description of the repo and update the settings file
+    local repo_description=$(gh repo view --json description --jq '.description')
+    local repo_homepage=$(gh repo view --json homepageUrl --jq '.homepageUrl')
+    local repo_topics=$(gh api repos/{owner}/{repo}/topics --jq '.names | join(", ")')
+
+    yq -ei ".repository.name = \"$XARGS_REPO_NAME\"" $settings
+    yq -ei ".repository.description = \"$repo_description\"" $settings
+    if [ -z "$repo_homepage" ]; then
+        yq -ei ".repository.homepage = \"https://cloudposse.com/accelerate\"" $settings
+    else
+        yq -ei ".repository.homepage = \"$repo_homepage\"" $settings
+    fi
+    
+    yq -ei ".repository.topics = \"$repo_topics\"" $settings
+
+    # finally, let's sort the file so _extends is at the top.
+    yq -ei 'sort_keys(.)' $settings
+    sed -i '' '/# Upstream changes/d' $settings
+    yq -ei '(._extends | key) head_comment="Upstream changes from _extends are only recognized when modifications are made to this file in the default branch."' $settings
+    
+    git add $settings
+}

--- a/migrate/lib/github.sh
+++ b/migrate/lib/github.sh
@@ -1,0 +1,5 @@
+
+function delete_branch_protection() {
+    local default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+    gh api -X DELETE /repos/${XARGS_REPO_OWNER}/${XARGS_REPO_NAME}/branches/${default_branch}/protection
+}

--- a/migrate/lib/gitignore.sh
+++ b/migrate/lib/gitignore.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+function install_gitignore() {
+    if [ ! -f .gitignore ]; then
+        install .gitignore
+    fi
+}

--- a/migrate/lib/mergify.sh
+++ b/migrate/lib/mergify.sh
@@ -1,0 +1,34 @@
+function install_mergify() {
+    # IMPORTANT `settings.yml` uses `_extends` keyword and mergify uses `extends` keyword
+    info "Installing Mergify"
+    local config=".github/mergify.yml"
+
+    mkdir -p $(dirname $config)
+
+    case "${REPO_TYPE}" in
+        "terraform-provider")
+            rm -f $config
+            ;;
+        "terraform-module")
+            rm -f $config
+            ;;
+        "github-action")
+            rm -f $config
+            ;;
+    esac
+    
+    if [ -f $config ]; then
+        info "Mergify config already installed"
+        # Ensure it's always extending from the .github repo
+        yq -ei '.extends = ".github"' $config
+
+        # Remove the erroneous _extends key, if present
+        yq -ei 'del(._extends)' $config
+        return
+    else 
+        info "Mergify config not found, initializing to .github"
+        info "Creating $config"
+        echo "extends: .github" > $config
+    fi
+    git add $config
+}

--- a/migrate/lib/readme.py
+++ b/migrate/lib/readme.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# This implementation uses ruamel.yaml, a python library that can handle whitespace and comments.
+#
+# The first implementation attempted to use `yq` to parse the YAML file and update the badges section.
+# Unfortunately, yq loses whitespace, and rewrites any multi-line strings and quoted strings.
+# This caused the README.yaml to be reformatted and lose its original structure, which is not acceptable.
+# It turns out that many YAML processors (especially based on Go) do not properly handle whitespace, 
+# comments, and multi-line strings in YAML. 
+# - https://github.com/mikefarah/yq/discussions/1584
+# - https://github.com/go-yaml/yaml/issues/827
+# 
+
+import sys
+import os
+from ruamel.yaml import YAML
+
+def add_newlines_before_comments(data):
+    prev_item = None
+    for item in data.items():
+        key_node = item[0]
+        # Check if the current node has a comment
+        if hasattr(key_node, 'comment') and key_node.comment:
+            comment = key_node.comment[0]
+            if comment and prev_item and not (hasattr(prev_item, 'comment') and prev_item.comment):
+                # Add a newline before the current comment block only if the previous item does not have a comment
+                prev_item.comment[2] = ['\n']
+        prev_item = key_node
+
+
+def migrate_readme(readme_yaml="README.yaml"):
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.width = 4096  # Set to a large number to avoid line wrapping
+    data = None
+
+    documents = []
+
+    # Load the YAML file with potentially multiple documents
+    try:
+        with open(readme_yaml, 'r') as file:
+            documents = list(yaml.load_all(file))
+    except FileNotFoundError:
+        print(f"{readme_yaml} file not found.")
+        return
+
+    for data in documents:
+        
+        github_repo = data.get('github_repo', None)
+        if not github_repo or github_repo == "None":
+            if 'GITHUB_REPO' in os.environ:
+                data['github_repo'] = os.environ['GITHUB_REPO']
+                github_repo = data['github_repo']
+            else:        
+                print(f"github_repo is not set in the {readme_yaml} file.")
+                pass
+
+        if 'badges' in data and isinstance(data['badges'], list):
+            # Names of badges to be removed (substrings)
+            badges_to_remove = ['Codefresh', 'Build Status', 'Latest Release', 'Last Updated', 'Commit', 'GitHub Action Build Status', 'Discourse', 'Forum', 'Slack']
+
+            # Remove unwanted badges
+            data['badges'] = [badge for badge in data['badges'] if not any(removal_str in badge['name'].strip() for removal_str in badges_to_remove)]
+        else:
+            data['badges'] = []
+
+        # Add new badges
+        new_badges = [
+            {"name": "Latest Release", "image": f"https://img.shields.io/github/release/{github_repo}.svg?style=for-the-badge", "url": f"https://github.com/{github_repo}/releases/latest"},
+            {"name": "Last Updated", "image": f"https://img.shields.io/github/last-commit/{github_repo}.svg?style=for-the-badge", "url": f"https://github.com/{github_repo}/commits"},
+            {"name": "Slack Community", "image": "https://slack.cloudposse.com/for-the-badge.svg", "url": "https://slack.cloudposse.com"}
+        ]
+
+        # Add badges for specific workflow files if they exist
+        if os.path.isfile(".github/workflows/test.yml"):
+            new_badges.append({"name": "Tests", "image": f"https://img.shields.io/github/actions/workflow/status/{github_repo}/test.yml?style=for-the-badge", "url": f"https://github.com/{github_repo}/actions/workflows/test.yml"})
+
+        if os.path.isfile(".github/workflows/lambda.yml"):
+            new_badges.append({"name": "Tests", "image": f"https://img.shields.io/github/actions/workflow/status/{github_repo}/lambda.yml?style=for-the-badge", "url": f"https://github.com/{github_repo}/actions/workflows/lambda.yml"})
+
+        data['badges'].extend(new_badges)
+
+        # Ruamel accidentally deletes this comment sometimes when updating the badges
+        data.yaml_set_comment_before_after_key('related', before='\nList any related terraform modules that this module may be used with or that this module depends on.')
+
+        # Set 'contributors' section to an empty array, as we handle this now with an image
+        data['contributors'] = []
+
+        add_newlines_before_comments(data)
+        
+    # Write back the updated YAML with multiple documents
+    with open(readme_yaml, 'w') as file:
+        yaml.dump_all(documents, file)
+
+if __name__ == "__main__":
+    migrate_readme(sys.argv[1])

--- a/migrate/lib/readme.sh
+++ b/migrate/lib/readme.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+function migrate_readme() {
+
+    readme_yaml="${1:-README.yaml}"
+
+    if [ ! -f "${readme_yaml}" ]; then
+        error "${readme_yaml} file not found."
+    fi
+    # This is used in the event `github_repo` is not properly set in the `README.yaml`
+    export GITHUB_REPO="${XARGS_REPO_OWNER}/${XARGS_REPO_NAME}"
+    ${MIGRATE_PATH}/lib/readme.py ${readme_yaml}
+}
+
+
+function rebuild_readme() {
+  if [ ! -f README.yaml ]; then
+    info "README.yaml file not found, skipping..."
+    return 0
+  fi
+
+  make readme
+
+  git add README.md
+}
+
+function generate_description() {
+  local description=$(cat README.yaml *.tf | \
+    mods --no-cache --quiet --word-wrap=2048 --raw -f \
+      'Provide a clear 1-3 sentence description in a spartan conversational tone, that describes this terraform module suitable \
+      for inclusion in the README.md of the module. Respond with GitHub flavored markdown and use links where appropriate. The target \
+      audience is developers with terraform knowledge. Do not link the Terraform term. Do not link to the module you are describing. \
+      Use code ticks for things like shell commands, terraform resources, modules or kubernetes resource definitions. Avoid too many adjectives \
+      or hyperbole. Focus on what it is and does.')
+
+}
+
+function generate_introduction() {
+  local description=$(cat README.yaml *.tf | \
+    mods --no-cache --quiet --word-wrap=2048 --raw -f \
+      'Act as an expert technical documentation writer with experience writing technical documentation for Open Source projects. \
+      Write a thorough explanation for a chapter of a REAMDE that explains what this module does in a spartan conversational tone written by an experienced DevOps engineer.\
+      Focus on what it is and does. Use concrete terms of what it does, not aspirations and endeavors. \
+      It can be as long as necessary. \
+      Add a section called "Key Features" which very succinctly highlights to top features of the module, but do not include the examples or features of the examples that do not directly relate to the module. \
+      This feature list should be a bulleted list. 
+      This repo is identified by the "github_repo" key in the README.yaml file. \
+      Respond with GitHub flavored markdown and use links where appropriate. \
+      The target audience is developers with terraform knowledge. \
+      If discussing Cloud Posse, link to https://cloudposse.com, but only the first time per paragraph. Use "Cloud Posse" instead of "CloudPosse" \
+      Use code ticks for things like shell commands, terraform resources, modules or kubernetes resource definitions. \  
+      Link to any modules referenced, with exception of the current module. \
+      For AWS services, link to the most relevant page in the AWS documentation. \
+      For each AWS service used by the module, explain succinctly what it is and the benefit of why it is used. \
+      For example, if you are using an S3 bucket, link to the S3 documentation.\
+      This explanation will be present within the repository itself, so do not directly suggest to visit module or repository itself.\
+      We discuss related modules elsewhere, so only bring up the most relevant ones here, if necessary.
+      Any modules discussed should also be linked to their documentation. \
+      Any terraform resources referenced should be linked to their documentation. \
+      Combine many one sentence parargraphs into a single paragraph. \
+      Do not use fancy words like "repertoire" or try to sound cute. \
+      Do not say things like as stated in the documentation or as stated in the README. \
+      Do not use the "related" or "references" section from the README.yaml as part of the description. \
+      Do not say "This repository" or "This project". \
+      Do not state the obvious. \
+      DO not state things such as "This module is a Terraform module" or that they need to have an AWS account or login credentials or the benefits in general of using modules.\
+      Do not say things like "Go back to the index" or "Read the next chapter" as this is not a book. \
+      Do not repeat the name of the current module multiple times in the explanation. 
+      Do not reuse the same phrases repeatedly like "key feature" over and over again. \
+      Do not use too many adjectives and avoid hyperbole. \
+      Do not add a conclusion or summary.\
+      Do not break it into additional chapters, unless asked. \
+      Do not add a title. \
+      Do not link the Terraform term. \
+      Do not link to the module you are describing. \
+      Do not say anything like "this module presupposes general background knowledge" \
+      Do not discuss cost of provisioning the resources. \
+      Do not link to any other chapters with anchors. \
+      Do not include example usage, or further information as the focus needs to be on the module itself. \
+      ')
+}

--- a/migrate/lib/renovate.sh
+++ b/migrate/lib/renovate.sh
@@ -1,0 +1,4 @@
+function install_renovate() {
+  info "Installing Renovate"
+  install .github/renovate.json
+}

--- a/migrate/migrations/20240618/README.md
+++ b/migrate/migrations/20240618/README.md
@@ -1,0 +1,5 @@
+## what
+- Update workflows (`.github/workflows/`) to use `cloudposse-github-actions` org workflows 
+
+## why
+- Part of migration GHA to `cloudposse-github-actions` org

--- a/migrate/migrations/20240618/repos-00
+++ b/migrate/migrations/20240618/repos-00
@@ -1,0 +1,4 @@
+cloudposse-github-actions/test-action
+cloudposse-github-actions/typescript-template
+cloudposse-github-actions/string-transformer
+cloudposse-github-actions/composite-template

--- a/migrate/migrations/20240618/repos.txt
+++ b/migrate/migrations/20240618/repos.txt
@@ -1,0 +1,4 @@
+cloudposse-github-actions/test-action
+cloudposse-github-actions/typescript-template
+cloudposse-github-actions/string-transformer
+cloudposse-github-actions/composite-template

--- a/migrate/migrations/20240618/script.sh
+++ b/migrate/migrations/20240618/script.sh
@@ -1,0 +1,6 @@
+title "Update release workflow to allow pull-requests: write"
+
+install .github/workflows/release.yml
+
+# Merge the PR
+auto_merge

--- a/migrate/run.sh
+++ b/migrate/run.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# IMPORTANT: This script should be invoked by `git-xargs`
+#
+
+export LABELS="auto-update,migration,no-release"
+export YAMLFIX_CONFIG_PATH="${MIGRATE_PATH}/yamlfix.yml"
+# Check if MIGRATE_PATH is not set
+if [ -z "${MIGRATE_PATH}" ]; then
+    echo "Error: MIGRATE_PATH is not set; this should be the base path where the migrations folder exists."
+    exit 1
+fi
+
+# Check if MIGRATE_PATH does not exist
+if [ ! -d "${MIGRATE_PATH}" ]; then
+    echo "Error: MIGRATE_PATH does not exist: ${MIGRATE_PATH}"
+    exit 1
+fi
+
+migration=$1
+migration_path=${MIGRATE_PATH}/migrations/$migration
+migration_script=${migration_path}/script.sh
+migration_readme=${migration_path}/README.md
+curdir=$(pwd)
+
+if [ -z "${migration}" ]; then
+    echo "Error: No migration specified"
+    exit 1
+fi
+
+if [ ! -f "${migration_script}" ]; then
+    echo "Error: Migration not found: $migration_script"
+    exit 1
+fi
+
+# Check if XARGS_DRY_RUN, XARGS_REPO_NAME, or XARGS_REPO_OWNER is not set
+if [[ -z "$XARGS_DRY_RUN" || -z "$XARGS_REPO_NAME" || -z "$XARGS_REPO_OWNER" ]]; then
+    echo "Error: This script should be invoked via git-xargs."
+    exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Identify the default branch
+default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+
+# Ensure our branch is reset to match the remote default branch, so that we can apply the migration cleanly
+git reset --hard origin/${default_branch}
+
+# Use migration's `.gitignore`, since not all repos have one
+git config --local core.excludesFile ${MIGRATE_PATH}/.gitignore
+
+# Clone the `build-harness` to a centralized location so we don't have to do it for every migration
+if [ ! -d "${MIGRATE_PATH}/tmp/build-harness" ]; then
+    git clone https://github.com/cloudposse/build-harness.git "$(dirname ${curdir})/build-harness"
+fi
+
+# Load all the helper functions
+for script in ${MIGRATE_PATH}/lib/*.sh; do
+    set -e
+    source "$script"
+    set +e
+done
+
+# Export the repo type
+repo_type
+
+if [ -d "${MIGRATE_PATH}/templates/${REPO_TYPE}" ]; then
+    info "Using ${REPO_TYPE} repository type for (${XARGS_REPO_NAME})"
+else
+    error "Error: No templates found for repository type: ${REPO_TYPE}"
+fi
+
+# Perform the actual migration
+set -e
+info "Starting migration $migration"
+source ${MIGRATE_PATH}/migrations/$migration/script.sh
+set +e
+
+# due to a bug in `git-xargs`, we need to clean up manually before exiting
+# https://github.com/gruntwork-io/git-xargs/issues/53
+git clean -fxd
+
+# Commit the changes
+git commit -a --message "chore: ${TITLE}"
+
+# Get the differences between the current branch and the default branch
+diff=$(git diff origin/${default_branch}...HEAD)
+
+# Check if there are any changes
+if [ -z "$diff" ]; then
+  info "No changes relative to main; not creating a PR."
+  # Check if the remote branch exists
+  if git ls-remote --heads origin "${current_branch}" | grep -q "${current_branch}"; then
+    info "Remote branch exists. Deleting..."
+    git push origin --delete "${current_branch}"
+  fi
+  exit 0
+fi
+
+if [ "${current_branch}" != "${default_branch}" ]; then
+    git push origin HEAD --force
+fi
+
+if [  "${XARGS_DRY_RUN}" == "false" ]; then
+    # First, we have to ensure labels already exist. They will not be created on-demand.
+    create_labels
+
+    # Create or update the pull request
+    gh pr create --title="${TITLE}" --body-file=${migration_readme} --label="${LABELS}" || \
+        gh pr edit --title="${TITLE}" --body-file=${migration_readme} --add-label="${LABELS}"
+    info "PR: $(gh pr view --json url --jq .url)"
+    gh pr view --json url --jq .url >> ${MIGRATE_PATH}/pr.log
+    # Automatically merge this PR after checks pass, using admin privileges to bypass branch protections.
+    # Then delete the branch.
+    if [ "${AUTO_MERGE}" == "true" ]; then
+        info "Auto-merging PR"
+        gh pr merge --admin --squash --delete-branch
+    fi
+else
+		info "https://github.com/${XARGS_REPO_OWNER}/${XARGS_REPO_NAME}/compare/${current_branch}?expand=1"
+		info "Dry run complete. No PR created."
+fi
+
+# Clean up again, so that `git-xargs` doesn't commit the cache files from `gh` cli in the `tmp/` folder
+git clean -fxd

--- a/migrate/templates/github-action/.github/workflows/branch.yml
+++ b/migrate/templates/github-action/.github/workflows/branch.yml
@@ -1,0 +1,26 @@
+name: Branch
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - release/v*
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'test/**'
+      - 'README.md'
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  github-action:
+    uses: cloudposse-github-actions/.github/.github/workflows/shared-github-action.yml@main
+    secrets: inherit

--- a/migrate/templates/github-action/.github/workflows/release.yml
+++ b/migrate/templates/github-action/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  github-action:
+    uses: cloudposse-github-actions/.github/.github/workflows/shared-release-branches.yml@main
+    secrets: inherit


### PR DESCRIPTION
## what
* Migrate GHA

## why
* Move all GHA to `cloudposse-github-actions` org

## Migration path
1. Accept `the GitHub Marketplace Developer Agreement` https://github.com/cloudposse-github-actions/test-action/releases/edit/0.1.0
2. Drop https://github.com/cloudposse-github-actions/test-action repo
3. Transfer [cloudposse/test-action](https://github.com/cloudposse/test-action) to [cloudposse-github-actions/test-action](https://github.com/cloudposse-github-actions/test-action)
4. Transfer [cloudposse/github-action-typescript-template](https://github.com/cloudposse/github-action-typescript-template) to [cloudposse-github-actions/typescript-template](https://github.com/cloudposse-github-actions/typescript-template) 
5. Transfer [cloudposse/github-action-string-transformer](https://github.com/cloudposse/github-action-string-transformer) to [cloudposse-github-actions/string-transformer](https://github.com/cloudposse-github-actions/string-transformer) 
6. Transfer [cloudposse/example-github-action-composite](https://github.com/cloudposse/example-github-action-composite) to [cloudposse-github-actions/composite-template](https://github.com/cloudposse-github-actions/composite-template) 
7. Merge https://github.com/cloudposse-github-actions/security/pull/5
8. Run migration https://github.com/cloudposse-github-actions/security/pull/5


